### PR TITLE
feat: Parameterize the input point cloud topic

### DIFF
--- a/include/small_gicp_relocalization/small_gicp_relocalization.hpp
+++ b/include/small_gicp_relocalization/small_gicp_relocalization.hpp
@@ -64,6 +64,7 @@ private:
   std::string robot_base_frame_;
   std::string lidar_frame_;
   std::string current_scan_frame_id_;
+  std::string input_cloud_topic;
   rclcpp::Time last_scan_time_;
   Eigen::Isometry3d result_t_;
   Eigen::Isometry3d previous_result_t_;

--- a/launch/small_gicp_relocalization_launch.py
+++ b/launch/small_gicp_relocalization_launch.py
@@ -43,6 +43,7 @@ def generate_launch_description():
                 "base_frame": "",
                 "lidar_frame": "",
                 "prior_pcd_file": "",
+                "input_cloud_topic": "cloud_registered",
             }
         ],
     )

--- a/src/small_gicp_relocalization.cpp
+++ b/src/small_gicp_relocalization.cpp
@@ -40,6 +40,7 @@ SmallGicpRelocalizationNode::SmallGicpRelocalizationNode(const rclcpp::NodeOptio
   this->declare_parameter("lidar_frame", "");
   this->declare_parameter("prior_pcd_file", "");
   this->declare_parameter("init_pose", std::vector<double>{0., 0., 0., 0., 0., 0.});
+  this->declare_parameter("input_cloud_topic","registered_scan");
 
   this->get_parameter("num_threads", num_threads_);
   this->get_parameter("num_neighbors", num_neighbors_);
@@ -53,6 +54,7 @@ SmallGicpRelocalizationNode::SmallGicpRelocalizationNode(const rclcpp::NodeOptio
   this->get_parameter("lidar_frame", lidar_frame_);
   this->get_parameter("prior_pcd_file", prior_pcd_file_);
   this->get_parameter("init_pose", init_pose_);
+  this->get_parameter("input_cloud_topic",input_cloud_topic);
 
   // [x, y, z, roll, pitch, yaw] - init_pose parameters
   if (!init_pose_.empty() && init_pose_.size() >= 6) {
@@ -88,7 +90,7 @@ SmallGicpRelocalizationNode::SmallGicpRelocalizationNode(const rclcpp::NodeOptio
     target_, small_gicp::KdTreeBuilderOMP(num_threads_));
 
   pcd_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-    "registered_scan", 10,
+    input_cloud_topic, 10,
     std::bind(&SmallGicpRelocalizationNode::registeredPcdCallback, this, std::placeholders::_1));
 
   initial_pose_sub_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -102,6 +104,8 @@ SmallGicpRelocalizationNode::SmallGicpRelocalizationNode(const rclcpp::NodeOptio
   transform_timer_ = this->create_wall_timer(
     std::chrono::milliseconds(50),  // 20 Hz
     std::bind(&SmallGicpRelocalizationNode::publishTransform, this));
+  //Debug Info
+  std::cout <<"\033[1;33mInput Cloud Topic: " << input_cloud_topic << "\033[0m" << std::endl;
 }
 
 void SmallGicpRelocalizationNode::loadGlobalMap(const std::string & file_name)


### PR DESCRIPTION
This pull request introduces a configurable topic name for the input point cloud in the small GICP relocalization node, improving flexibility for different setups. The main changes include adding a new parameter for the input cloud topic, updating its usage throughout the codebase, and providing a debug print for the selected topic.

Parameterization and usage of input cloud topic:

* Added a new member variable `input_cloud_topic` to the `SmallGicpRelocalizationNode` class to store the topic name.
* Declared and retrieved the `input_cloud_topic` parameter in the node constructor, allowing it to be set via launch files or configuration. [[1]](diffhunk://#diff-5e6c032361350c60c887d38bc9a739f4f0772602ae84d0f93000d7b9c2d12457R43) [[2]](diffhunk://#diff-5e6c032361350c60c887d38bc9a739f4f0772602ae84d0f93000d7b9c2d12457R57)
* Updated the point cloud subscription to use the configurable `input_cloud_topic` instead of the hardcoded `"registered_scan"`.

Launch configuration and debugging:

* Added `input_cloud_topic` to the launch file default parameters, making it easy to override the topic at launch time.
* Added a debug print statement to output the selected input cloud topic when the node starts.